### PR TITLE
CN-145 nvidia security updates

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -131,7 +131,7 @@ To use baski to build an image, an Openstack cluster is required.`,
 			}
 
 			buildGitDir := CreateRepoDirectory()
-			FetchBuildRepo(buildGitDir, viper.GetString("build.image-repo"), viper.GetBool("build.enable-nvidia-support"))
+			FetchBuildRepo(buildGitDir, viper.GetString("build.image-repo"), viper.GetBool("build.enable-nvidia-support"), viper.GetBool("build.add-trivy"), viper.GetBool("build.add-falco"))
 
 			metadata := ostack.GenerateBuilderMetadata()
 			err := ostack.UpdatePackerBuildersJson(buildGitDir, metadata)

--- a/pkg/cmd/build/process.go
+++ b/pkg/cmd/build/process.go
@@ -48,12 +48,16 @@ func CreateRepoDirectory() string {
 }
 
 // FetchBuildRepo simply pulls the contents of the imageRepo to the specified path
-func FetchBuildRepo(path, imageRepo string, gpuSupport bool) {
+func FetchBuildRepo(path, imageRepo string, gpuSupport, addTrivy, addFalco bool) {
 	var branch plumbing.ReferenceName
 	branch = plumbing.Master
 
-	if gpuSupport {
-		branch = "refs/heads/nvidia-driver-support"
+	//FIXME: This check is in place until the nvidia branch and security branch in this repo go upstream.
+	// Until it has been added, we must force users over to this repo as it's the only one that has these new additions.
+	if gpuSupport || addTrivy || addFalco {
+		log.Println("the kubernetes sigs project doesn't currently support nvidia, falco or trivy. Using https://github.com/eschercloudai/image-builder.git until it's pushed upstream")
+		imageRepo = "https://github.com/eschercloudai/image-builder.git"
+		branch = "refs/heads/nvidia-security"
 	}
 
 	_, err := gitRepo.GitClone(imageRepo, path, branch)

--- a/pkg/cmd/scan/process.go
+++ b/pkg/cmd/scan/process.go
@@ -84,7 +84,7 @@ func RemoveScanningResources(serverID, keyName string, os *ostack.Client) {
 }
 
 // CheckForVulnerabilities will scan the results file for any 7+ CVE scores and if so will delete the image from Openstack and bail out here.
-func CheckForVulnerabilities(checkScore float64, checkSeverity string) []trivy.Vulnerabilities {
+func CheckForVulnerabilities(checkScore float64, checkSeverity string) []trivy.ScanFailedReport {
 	log.Println("checking results for failures")
 	rf, err := os.ReadFile("/tmp/results.json")
 	if err != nil {
@@ -101,19 +101,17 @@ func CheckForVulnerabilities(checkScore float64, checkSeverity string) []trivy.V
 		return nil
 	}
 
-	var vf []trivy.Vulnerabilities
+	var vf []trivy.ScanFailedReport
 
 	for _, r := range report.Results {
 		for _, v := range r.Vulnerabilities {
 			if checkSeverityThresholdPassed(v.Severity, v.Cvss, checkScore, checkSeverity) {
-				vuln := trivy.Vulnerabilities{
+				vuln := trivy.ScanFailedReport{
 					VulnerabilityID:  v.VulnerabilityID,
 					PkgName:          v.PkgName,
 					InstalledVersion: v.InstalledVersion,
 					FixedVersion:     v.FixedVersion,
 					Severity:         v.Severity,
-					PublishedDate:    v.PublishedDate,
-					LastModifiedDate: v.LastModifiedDate,
 				}
 				// We don't need all scores in here, so we just grab the one that triggered the threshold
 				if v.Cvss.Nvd != nil {

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -69,12 +69,16 @@ func NewScanCommand() *cobra.Command {
 Scanning an image requires the creation of a new instance in Openstack using the image you want to scan.
 Then, Trivy needs downloading and running against the filesystem. Again, this is time consuming.
 
-The scan section of baski fixes this for you and allows you to drink coffee whilst it does the hard work for you.
+The scan section of Baski fixes this for you and allows you to drink <enter drink here> whilst it does the hard work for you.
 
-It creates a new instance using the provided Openstack configuration variables and scans the image.
-Once complete, it generates a report file that you can read,
-OR!
-Use the publish command to create a "pretty" interface in GitHub Pages through which you can browse the results.`,
+It does the following:
+* Creates a new instance using the provided Openstack configuration variables
+* Check if Trivy is available already, if not it'll download it
+* Scans the rootfs
+* Generates a report file that you can read with your eyes or via other means
+
+If the checks for CVE flags/config values are set then it will bail out and generate a report with the CVEs that caused it to do so.
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if !trivy.ValidSeverity(strings.ToUpper(viper.GetString("scan.max-severity-type"))) {
@@ -122,7 +126,7 @@ Use the publish command to create a "pretty" interface in GitHub Pages through w
 						log.Fatalln("couldn't write vulnerability data to file")
 					}
 
-					log.Fatalln("Vulnerabilities detected above threshold - removed image from infra. Please see the possible fixes located at '/tmp/required-fixes.json' for further information on this.")
+					log.Fatalln("Vulnerabilities detected above threshold - removed image from infra. Please see the possible fixes located at '/tmp/results.json' for further information on this.")
 				}
 			}
 

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -147,9 +147,11 @@ func (c *Client) CreateServer(keypair *keypairs.KeyPair, imageID, flavorName, ne
 		ImageRef:       imageID,
 		SecurityGroups: []string{"default"},
 		UserData: []byte(fmt.Sprintf(`#!/bin/bash
-wget -q -O- "https://github.com/aquasecurity/trivy/releases/download/v%s/trivy_%s_Linux-64bit.tar.gz" | tar xzf -
-chmod u+x trivy
-sudo ./trivy rootfs --scanners vuln -f json -o /tmp/results.json /
+if ! command -v trivy &> /dev/null; then
+wget -q -O- "https://github.com/aquasecurity/trivy/releases/download/v%s/trivy_%s_Linux-64bit.tar.gz" | tar xzf -;
+chmod u+x trivy;
+fi
+sudo trivy rootfs --scanners vuln -f json -o /tmp/results.json /
 `, trivyVersion, trivyVersion)),
 		AvailabilityZone: "",
 		Networks: []servers.Network{

--- a/pkg/trivy/report.go
+++ b/pkg/trivy/report.go
@@ -60,6 +60,15 @@ func parseSeverity(val Severity) int {
 	return 0
 }
 
+type ScanFailedReport struct {
+	VulnerabilityID  string `json:"VulnerabilityID"`
+	PkgName          string `json:"PkgName"`
+	InstalledVersion string `json:"InstalledVersion"`
+	Severity         string `json:"Severity"`
+	Cvss             CVSS   `json:"CVSS"`
+	FixedVersion     string `json:"FixedVersion"`
+}
+
 // Report and all its sub-structs is used to unmarshal the json reports into a usable format.
 type Report struct {
 	SchemaVersion int    `json:"SchemaVersion"`


### PR DESCRIPTION
Added Falco and Trivy install options to the build - set a hardcode to eschercloud image builder if those or nvidia are set as this is the only repo that supports it.