### PR TITLE
fix: changed fip selection to fip creation to prevent race condition 

### DIFF
--- a/pkg/cmd/scan/process.go
+++ b/pkg/cmd/scan/process.go
@@ -21,6 +21,7 @@ import (
 	ostack "github.com/eschercloudai/baski/pkg/openstack"
 	sshconnect "github.com/eschercloudai/baski/pkg/ssh"
 	"github.com/eschercloudai/baski/pkg/trivy"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/pkg/sftp"
 	"log"
@@ -78,9 +79,10 @@ func FetchResultsFromServer(freeIP string, kp *keypairs.KeyPair) error {
 }
 
 // RemoveScanningResources cleans up the server and keypair from Openstack to ensure nothing is left lying around.
-func RemoveScanningResources(serverID, keyName string, os *ostack.Client) {
+func RemoveScanningResources(serverID, keyName string, fip *floatingips.FloatingIP, os *ostack.Client) {
 	os.RemoveServer(serverID)
 	os.RemoveKeypair(keyName)
+	os.RemoveFIP(fip)
 }
 
 // CheckForVulnerabilities will scan the results file for any 7+ CVE scores and if so will delete the image from Openstack and bail out here.

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -19,6 +19,7 @@ package scan
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/eschercloudai/baski/pkg/cmd/util/flags"
 	"log"
 	"os"
@@ -69,10 +70,10 @@ If the checks for CVE flags/config values are set then it will bail out and gene
 				panic(err)
 			}
 
-			fip, err := osClient.GetFloatingIP()
+			fmt.Println(strings.ToLower(o.FloatingIPNetworkName))
+			fip, err := osClient.GetFloatingIP(strings.ToLower(o.FloatingIPNetworkName))
 			if err != nil {
 				osClient.RemoveKeypair(kp.Name)
-				osClient.RemoveFIP(fip)
 				panic(err)
 			}
 

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -18,10 +18,12 @@ package scan
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/eschercloudai/baski/pkg/cmd/util/flags"
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	ostack "github.com/eschercloudai/baski/pkg/openstack"
 	"github.com/eschercloudai/baski/pkg/trivy"
@@ -62,19 +64,53 @@ If the checks for CVE flags/config values are set then it will bail out and gene
 
 			osClient := ostack.NewOpenstackClient(cloudsConfig.Clouds[o.CloudName])
 
-			kp := osClient.CreateKeypair(o.ImageID)
-			server, freeIP := osClient.CreateServer(kp, o)
-
-			err := FetchResultsFromServer(freeIP, kp)
+			kp, err := osClient.CreateKeypair(o.ImageID)
 			if err != nil {
-				RemoveScanningResources(server.ID, kp.Name, osClient)
+				panic(err)
+			}
+
+			fip, err := osClient.GetFloatingIP()
+			if err != nil {
+				osClient.RemoveKeypair(kp.Name)
+				osClient.RemoveFIP(fip)
+				panic(err)
+			}
+
+			server, err := osClient.CreateServer(kp, o, fip.IP)
+			if err != nil {
+				osClient.RemoveKeypair(kp.Name)
+				osClient.RemoveFIP(fip)
+				panic(err)
+			}
+
+			state := osClient.GetServerStatus(server.ID)
+			checkLimit := 0
+			for !state {
+				if checkLimit > 100 {
+					panic(errors.New("server failed to com online after 500 seconds"))
+				}
+				log.Println("server not active, waiting 5 seconds and then checking again")
+				time.Sleep(5 * time.Second)
+				state = osClient.GetServerStatus(server.ID)
+				checkLimit++
+			}
+
+			err = osClient.AttachIP(server.ID, fip.IP)
+			if err != nil {
+				RemoveScanningResources(server.ID, kp.Name, fip, osClient)
+				panic(err)
+			}
+
+			err = FetchResultsFromServer(fip.IP, kp)
+			if err != nil {
+				RemoveScanningResources(server.ID, kp.Name, fip, osClient)
 				log.Fatalln(err.Error())
 			}
 			if !o.SkipCVECheck {
 				scoreCheck := CheckForVulnerabilities(o.MaxSeverityScore, strings.ToUpper(o.MaxSeverityType))
 				if len(scoreCheck) != 0 {
 					// Cleanup the scanning resources
-					RemoveScanningResources(server.ID, kp.Name, osClient)
+					RemoveScanningResources(server.ID, kp.Name, fip, osClient)
 
 					if o.AutoDeleteImage {
 						osClient.RemoveImage(o.ImageID)
@@ -103,7 +139,7 @@ If the checks for CVE flags/config values are set then it will bail out and gene
 			}
 
 			// Cleanup the scanning resources
-			RemoveScanningResources(server.ID, kp.Name, osClient)
+			RemoveScanningResources(server.ID, kp.Name, fip, osClient)
 		},
 	}
 

--- a/pkg/cmd/util/flags/scan.go
+++ b/pkg/cmd/util/flags/scan.go
@@ -7,8 +7,7 @@ import (
 )
 
 type ScanOptions struct {
-	OpenStackCoreFlags
-	OpenStackInstanceFlags
+	OpenStackFlags
 
 	ImageID          string
 	AutoDeleteImage  bool
@@ -18,8 +17,7 @@ type ScanOptions struct {
 }
 
 func (o *ScanOptions) SetOptionsFromViper() {
-	o.OpenStackCoreFlags.SetSignOptionsFromViper()
-	o.OpenStackInstanceFlags.SetSignOptionsFromViper()
+	o.OpenStackFlags.SetSignOptionsFromViper()
 
 	o.ImageID = viper.GetString(fmt.Sprintf("%s.image-id", viperScanPrefix))
 	o.AutoDeleteImage = viper.GetBool(fmt.Sprintf("%s.auto-delete-image", viperScanPrefix))
@@ -29,8 +27,7 @@ func (o *ScanOptions) SetOptionsFromViper() {
 }
 
 func (o *ScanOptions) AddFlags(cmd *cobra.Command) {
-	o.OpenStackCoreFlags.AddFlags(cmd, viperOpenStackPrefix)
-	o.OpenStackInstanceFlags.AddFlags(cmd, viperOpenStackPrefix)
+	o.OpenStackFlags.AddFlags(cmd, viperOpenStackPrefix)
 
 	StringVarWithViper(cmd, &o.ImageID, viperScanPrefix, "image-id", "", "The ID of the image to scan")
 	BoolVarWithViper(cmd, &o.AutoDeleteImage, viperScanPrefix, "auto-delete-image", false, "If true, the image will be deleted if a vulnerability check does not succeed - recommended when building new images.")

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -255,10 +255,10 @@ func (c *Client) GetFlavorIDByName(name string) string {
 }
 
 // GetFloatingIP will create a new FIP.
-func (c *Client) GetFloatingIP() (*floatingips.FloatingIP, error) {
+func (c *Client) GetFloatingIP(ipPool string) (*floatingips.FloatingIP, error) {
 	client := createComputeClient(c)
 	createOpts := floatingips.CreateOpts{
-		Pool: "internet", // TODO: This should be a variable really but for now let's just presume this because, you know...
+		Pool: ipPool,
 	}
 
 	fip, err := floatingips.Create(client, createOpts).Extract()

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -19,11 +19,6 @@ package ostack
 import (
 	"fmt"
 	"github.com/eschercloudai/baski/pkg/cmd/util/flags"
-	"log"
-	"strconv"
-	"strings"
-	"time"
-
 	"github.com/eschercloudai/baski/pkg/constants"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -32,6 +27,9 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"log"
+	"strconv"
+	"strings"
 )
 
 // Client contains the Env vars of the program as well as the Provider and any EndpointOptions.
@@ -120,7 +118,7 @@ func createComputeClient(client *Client) *gophercloud.ServiceClient {
 }
 
 // CreateKeypair creates a new KeyPair in Openstack.
-func (c *Client) CreateKeypair(keyNamePrefix string) *keypairs.KeyPair {
+func (c *Client) CreateKeypair(keyNamePrefix string) (*keypairs.KeyPair, error) {
 	client := createComputeClient(c)
 	client.Microversion = "2.2"
 
@@ -129,14 +127,24 @@ func (c *Client) CreateKeypair(keyNamePrefix string) *keypairs.KeyPair {
 		Type: "ssh",
 	}).Extract()
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 
-	return kp
+	return kp, nil
+}
+
+// RemoveKeypair will delete a Keypair from Openstack.
+func (c *Client) RemoveKeypair(keyName string) {
+	log.Println("removing keypair.")
+	client := createComputeClient(c)
+	res := keypairs.Delete(client, keyName, keypairs.DeleteOpts{})
+	if res.Err != nil {
+		log.Println(res.Err)
+	}
 }
 
 // CreateServer creates a compute instance in Openstack.
-func (c *Client) CreateServer(keypair *keypairs.KeyPair, o *flags.ScanOptions) (*servers.Server, string) {
+func (c *Client) CreateServer(keypair *keypairs.KeyPair, o *flags.ScanOptions, fip string) (*servers.Server, error) {
 	client := createComputeClient(c)
 
 	serverFlavorID := c.GetFlavorIDByName(o.FlavorName)
@@ -172,14 +180,41 @@ sudo trivy rootfs --scanners vuln -f json -o /tmp/results.json /
 
 	server, err := servers.Create(client, createOpts).Extract()
 	if err != nil {
-		c.RemoveKeypair(keypair.Name)
-		panic(err)
+		return nil, err
 	}
 
-	//TODO: If no IP is available, allocate one and attach. If none available to allocate, fail.
-	freeIP := attachFloatingIP(client, server.ID)
+	return server, nil
+}
 
-	return server, freeIP
+// GetServerStatus gets the status of a server
+func (c *Client) GetServerStatus(sid string) bool {
+	client := createComputeClient(c)
+
+	state, err := servers.Get(client, sid).Extract()
+	if err != nil {
+		log.Println(err)
+		return false
+	}
+	if state.Status != "ACTIVE" {
+		return false
+	}
+
+	return true
+}
+
+// AttachIP attaches the provided IP to the provided server.
+func (c *Client) AttachIP(serverID, fip string) error {
+	client := createComputeClient(c)
+
+	associateOpts := floatingips.AssociateOpts{
+		FloatingIP: fip,
+	}
+
+	err := floatingips.AssociateInstance(client, serverID, associateOpts).ExtractErr()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // RemoveServer will delete a Server from Openstack.
@@ -188,16 +223,6 @@ func (c *Client) RemoveServer(serverID string) {
 	client := createComputeClient(c)
 	res := servers.Delete(client, serverID)
 
-	if res.Err != nil {
-		log.Println(res.Err)
-	}
-}
-
-// RemoveKeypair will delete a Keypair from Openstack.
-func (c *Client) RemoveKeypair(keyName string) {
-	log.Println("removing keypair.")
-	client := createComputeClient(c)
-	res := keypairs.Delete(client, keyName, keypairs.DeleteOpts{})
 	if res.Err != nil {
 		log.Println(res.Err)
 	}
@@ -229,45 +254,27 @@ func (c *Client) GetFlavorIDByName(name string) string {
 	return ""
 }
 
-// attachFloatingIP will find the first free IP available and attach it to the instance.
-// If it cannot find one, it will error.
-func attachFloatingIP(client *gophercloud.ServiceClient, serverID string) string {
-	// Floating IP assignment
-	allIPsPages, err := floatingips.List(client).AllPages()
+// GetFloatingIP will create a new FIP.
+func (c *Client) GetFloatingIP() (*floatingips.FloatingIP, error) {
+	client := createComputeClient(c)
+	createOpts := floatingips.CreateOpts{
+		Pool: "internet", // TODO: This should be a variable really but for now let's just presume this because, you know...
+	}
+
+	fip, err := floatingips.Create(client, createOpts).Extract()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	allFloatingIPs, err := floatingips.ExtractFloatingIPs(allIPsPages)
-	if err != nil {
-		panic(err)
+	return fip, nil
+}
+
+// RemoveFIP will delete a Floating IP from Openstack.
+func (c *Client) RemoveFIP(fip *floatingips.FloatingIP) {
+	log.Println("removing floating IP.")
+	client := createComputeClient(c)
+	res := floatingips.Delete(client, fip.ID)
+	if res.Err != nil {
+		log.Println(res.Err)
 	}
-
-	var freeIP string
-
-	for _, fip := range allFloatingIPs {
-		if fip.InstanceID == "" {
-			freeIP = fip.IP
-			break
-		}
-	}
-
-	if freeIP == "" {
-		panic("couldn't find a free IP")
-	}
-
-	log.Println("waiting for the instance to come up before attaching an IP")
-	time.Sleep(15 * time.Second)
-	log.Printf("attaching IP %s to the instance %s", freeIP, serverID)
-
-	associateOpts := floatingips.AssociateOpts{
-		FloatingIP: freeIP,
-	}
-
-	err = floatingips.AssociateInstance(client, serverID, associateOpts).ExtractErr()
-	if err != nil {
-		panic(err)
-	}
-
-	return freeIP
 }


### PR DESCRIPTION
This create a new process for getting Floating IPs onto the server in OpenStack. The previous approach looked for FIPs in the account and if it couldn't find one, would fail. The problem with this was if three scans ran at the same time there would be a fight over who got the IP and multiple servers may try to attach it at the same time. OpenStack wouldn't allow this but Baski was ignorant to this and so would try to continue.

Now a floating IP is allocated to the project as they are required preventing any race condition and it is released back into the pool after.

This PR also contains some improvements around how to detect errors during the process and separates some logic out such as creating a server and attaching an IP to it into separate processes to allow better detection of errors and to keep it SOLID.

Fixes #38